### PR TITLE
Add autobootstrapping of cluster

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     datacat: "https://github.com/richardc/puppet-datacat.git"
+    puppetdbquery: "https://github.com/dalen/puppet-puppetdbquery.git"
   symlinks:
     percona: "#{source_dir}"

--- a/lib/facter/percona_wsrep_cluster_size.rb
+++ b/lib/facter/percona_wsrep_cluster_size.rb
@@ -1,0 +1,12 @@
+Facter.add("percona_wsrep_cluster_size") do
+  setcode do
+    if File.file?("#{Facter.value(:root_home)}/.my.cnf")
+      status = Facter::Util::Resolution.exec('pgrep -f mysqld')
+      if ! status.empty?
+        Facter::Util::Resolution.exec('mysql -nNE -e "SHOW STATUS LIKE \'wsrep_cluster_size\';" | tail -1')
+      else
+        nil
+      end
+    end
+  end
+end

--- a/lib/puppet/parser/functions/percona_bootstrapnode_ip.rb
+++ b/lib/puppet/parser/functions/percona_bootstrapnode_ip.rb
@@ -1,0 +1,39 @@
+#
+# percona_bootstrapnode_ip.rb
+#
+#
+module Puppet::Parser::Functions
+  newfunction(:percona_bootstrapnode_ip, :type => :rvalue, :arity => 1, :doc => <<-EOS
+    Querys puppetdb and searches for a percona cluster member in bootstrap mode
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "percona_bootstrapnode_ip(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size != 1
+
+      res_filter = [
+        'and',
+        ['=', 'type', 'Percona::Stubs::Bootstrapnode'],
+        ['=', 'exported', true],
+        ['=', 'tag', arguments[0]],
+      ]
+
+      qry_res = self.function_query_resources([false, res_filter])
+
+      if qry_res.size > 0
+        raise(Puppet::ParseError, "percona_bootstrapnode_ip(): Found #{qry_res.size} percona nodes in bootstrap mode for tag '#{arguments[0]}', expected only one.") if qry_res.size > 1
+
+        if qry_res.is_a?(Hash)
+          qry_res = qry_res.values[0][0]['parameters']
+        else
+          qry_res = qry_res['parameters']
+        end
+
+        raise(Puppet::ParseError, "percona_bootstrapnode_ip(): Can not find parameter ip.") unless qry_res.has_key?('ip')
+
+        return qry_res['ip']
+
+      end
+      return nil
+  end
+end

--- a/lib/puppet/parser/functions/percona_cluster_nodecount.rb
+++ b/lib/puppet/parser/functions/percona_cluster_nodecount.rb
@@ -1,0 +1,25 @@
+#
+# percona_cluster_nodecount.rb
+#
+#
+module Puppet::Parser::Functions
+  newfunction(:percona_cluster_nodecount, :type => :rvalue, :arity => 1, :doc => <<-EOS
+    Querys puppetdb and searches for percona cluster members that match the tag given as first parameter, returns the count
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "percona_cluster_nodecount(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size != 1
+
+      res_filter = [
+        'and',
+        ['=', 'type', 'Percona::Stubs::Clusternode'],
+        ['=', 'exported', true],
+        ['=', 'tag', arguments[0]],
+      ]
+
+      qry_res = self.function_query_resources([false, res_filter])
+
+      qry_res.size
+  end
+end

--- a/lib/puppet/provider/percona_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/percona_conn_validator/tcp_port.rb
@@ -1,0 +1,51 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/util/percona_conn_validator'
+
+# This file contains a provider for the resource type `percona_conn_validator`,
+# which validates the Percona instance connection by attempting a tcp connection.
+
+Puppet::Type.type(:percona_conn_validator).provide(:tcp_port) do
+  desc "A provider for the resource type `percona_conn_validator`,
+        which validates the  connection by attempting a tcp
+        connection to the Percona instance."
+
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for the Percona instance to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 2
+      # seconds until the configurable timeout has expired.
+      Puppet.debug("Failed to connect to the Percona instance; sleeping 2 seconds before retry")
+      sleep 2
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to the Percona instance in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to connect to the Percona instance within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to Percona instance ! (#{@validator.instance_server}:#{@validator.instance_port})"
+  end
+
+  private
+
+  # @api private
+  def validator
+    @validator ||= Puppet::Util::PerconaConnValidator.new(resource[:server], resource[:port])
+  end
+
+end

--- a/lib/puppet/type/percona_conn_validator.rb
+++ b/lib/puppet/type/percona_conn_validator.rb
@@ -1,0 +1,38 @@
+Puppet::Type.newtype(:percona_conn_validator) do
+
+  @doc = "Verify that a connection can be successfully established between a node
+  and the Percona instance. It could potentially be used for other
+  purposes such as monitoring."
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:server) do
+    desc 'DNS name or IP address of the server where the Percona instance should be running.'
+    defaultto 'localhost'
+  end
+
+  newparam(:port) do
+    desc 'The port that the Percona instance should be listening on.'
+    defaultto 3306
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the Percona instance is not running; defaults to 60 seconds.'
+    defaultto 60
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet/util/percona_conn_validator.rb
+++ b/lib/puppet/util/percona_conn_validator.rb
@@ -1,0 +1,36 @@
+require 'socket'
+require 'timeout'
+
+module Puppet
+  module Util
+    class PerconaConnValidator
+      attr_reader :instance_server
+      attr_reader :instance_port
+
+      def initialize(instance_server, instance_port)
+        @instance_server = instance_server
+        @instance_port   = instance_port
+      end
+
+      # Utility method; attempts to make a tcp connection to the Percona instance.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        Timeout::timeout(Puppet[:configtimeout]) do
+          begin
+            TCPSocket.new(@instance_server, @instance_port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+            Puppet.debug "Unable to connect to Percona instance (#{@instance_server}:#{@instance_port}): #{e.message}"
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
+    end
+  end
+end
+

--- a/manifests/automatic_bootstrap.pp
+++ b/manifests/automatic_bootstrap.pp
@@ -1,0 +1,112 @@
+# == Class percona::create_node
+#
+class percona::automatic_bootstrap {
+
+  $min_nodes_required = 3
+  if $::percona::wsrep_cnf['mysqld']['wsrep_cluster_name'] {
+    $wsrep_cluster_name = $::percona::wsrep_cnf['mysqld']['wsrep_cluster_name']
+  } else {
+    fail("${name}: wsrep cluster name is not set")
+  }
+  if $::percona::wsrep_cnf['mysqld']['wsrep_node_address'] {
+    $node_address = $::percona::wsrep_cnf['mysqld']['wsrep_node_address']
+  } else {
+    $node_address = $::ipaddress
+  }
+
+  # Are we on the bootstrap node?
+  if $::percona::bootstrapnode {
+    # Have we been bootstrapped, yet?
+    if $::percona_db_initially_restarted {
+      # Node has been bootstrapped
+      # - export ourself as clusternode
+      @@::percona::stubs::clusternode { $::fqdn:
+        ip  => $node_address,
+        tag => "percona-cluster-${wsrep_cluster_name}",
+      }
+    } else {
+      # Node has not been bootstrapped, yet.
+      # - do nothing if the cluster has already been started once
+      # - export ourself as bootstrapnode
+      # - start the percona service in bootstrap mode
+      # - set fact to prevent automatic restarts in the future
+      if percona_cluster_nodecount("percona-cluster-${wsrep_cluster_name}") == 0 {
+        @@::percona::stubs::bootstrapnode { $::fqdn:
+          ip  => $node_address,
+          tag => "percona-bootstrap-${wsrep_cluster_name}",
+        }
+
+        service { $::percona::mysql_service_name:
+          ensure  => running,
+          enable  => false,
+          start   => $::percona::bootstrap_start_cmd,
+          require => Class['::percona::package'],
+        }
+
+        if defined(Class['::percona::prepare_db']) {
+          Service <| title == $::percona::mysql_service_name |> {
+            require +> Class['::percona::prepare_db'],
+          }
+        }
+      }
+
+      # Is the mysql service running and the fact percona_wsrep_cluster_size avaliable?
+      if $::percona_wsrep_cluster_size != undef {
+        # If the required node count is online, let's exit bootstrap mode
+        if $::percona_wsrep_cluster_size >= $min_nodes_required {
+
+          exec { "${name}-mysqld_restart_to_exit_bootstrap_mode":
+            path    => '/bin/:/sbin/:/usr/bin/:/usr/sbin/',
+            command => $::percona::bootstrap_stop_cmd,
+            onlyif  => 'test ! -z "$(pgrep -f wsrep-new-cluster)"',
+          }
+
+          ->
+          file { "${name}-percona_db_initially_restarted":
+            ensure  => file,
+            path    => '/etc/facter/facts.d/percona_db_initially_restarted.txt',
+            content => 'percona_db_initially_restarted=true',
+          }
+        }
+      }
+    }
+  } else {
+    # Not on the bootstrap host: start service once only if the master is available in bootstrap mode
+    $bootstrap_node_ip = percona_bootstrapnode_ip("percona-bootstrap-${wsrep_cluster_name}")
+
+    # This collector is functionally not necessary, we just add it for visibility
+    Percona::Stubs::Bootstrapnode <<| tag == "percona-bootstrap-${wsrep_cluster_name}" |>>
+
+    if $bootstrap_node_ip {
+      if $::percona_db_initially_started {
+        # Node has already been started automatically
+        # - export ourself as clusternode
+        @@::percona::stubs::clusternode { $::fqdn:
+          ip  => $node_address,
+          tag => "percona-cluster-${wsrep_cluster_name}",
+        }
+      } else {
+        # Node has never been startet automatically
+        # - check connectivity
+        # - start service
+        # - set fact to prevent automatic starts in the future
+        percona_conn_validator { 'bootstrap-node' :
+          server => $bootstrap_node_ip,
+          port   => '4567', # Connect on the port for group communication to make sure percona is running with galera
+        }
+
+        service { $::percona::mysql_service_name:
+          ensure  => running,
+          enable  => false,
+          require => Percona_conn_validator['bootstrap-node'],
+        }
+        ->
+        file { "${name}-percona_db_initially_started":
+          ensure  => file,
+          path    => '/etc/facter/facts.d/percona_db_initially_started.txt',
+          content => 'percona_db_initially_started=true',
+        }
+      }
+    }
+  }
+}

--- a/manifests/create_db_base.pp
+++ b/manifests/create_db_base.pp
@@ -2,23 +2,19 @@
 #
 class percona::create_db_base {
 
-  file { "${name}-etc_facter":
-    ensure => directory,
-    path   => '/etc/facter',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
-  }
-  ->
+  $facter_directories = [
+    '/etc/facter',
+    '/etc/facter/facts.d',
+  ]
 
-  file { "${name}-etc_facter_facts_d":
+  $facter_directories_params = {
     ensure => directory,
-    path   => '/etc/facter/facts.d',
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
   }
-  ->
+
+  ensure_resource('file', $facter_directories, $facter_directories_params)
 
   file { "${name}-my_cnf_d_dir":
     ensure  => directory,
@@ -28,6 +24,7 @@ class percona::create_db_base {
     mode    => '0755',
     purge   => true,
     recurse => true,
+    require => File[$facter_directories],
   }
   ->
 
@@ -73,6 +70,16 @@ class percona::create_db_base {
     group   => 'mysql',
     mode    => '0640',
     content => template('percona/node/admin_auth.cnf.erb'),
+  }
+
+  ->
+  file { "${name}-client_admin_auth_file_root_home":
+    ensure => link,
+    path   => "${::root_home}/.my.cnf",
+    target => '/etc/my.cnf.d/client/admin_auth.cnf',
+    owner  => 'mysql',
+    group  => 'mysql',
+    mode   => '0640',
   }
   ->
 

--- a/manifests/create_node.pp
+++ b/manifests/create_node.pp
@@ -57,6 +57,13 @@ class percona::create_node {
   unless str2bool($::percona_db_prepared) {
     class { '::percona::prepare_db':
       require => Exec["${name}-mysql_install_db"],
+      before  => Class['::percona::automatic_bootstrap'],
     }
+  }
+
+  if $::percona::automatic_bootstrap {
+    anchor {"${name}::begin": }          ->
+    class  {'::percona::automatic_bootstrap': } ->
+    anchor {"${name}::end": }
   }
 }

--- a/manifests/create_standalone.pp
+++ b/manifests/create_standalone.pp
@@ -2,15 +2,13 @@
 #
 class percona::create_standalone {
 
-  include ::percona::virtual::service
-
   exec { "${name}-mysql_install_db":
     command => '/usr/bin/mysql_install_db',
     onlyif  => "/usr/bin/test ! -d ${percona::mysql_datadir}/mysql",
   }
   ->
 
-  Service <| title == $percona::mysql_service_name |> {
+  service { $::percona::mysql_service_name:
     ensure => running,
     enable => true,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,12 @@
 #[*wsrep_cluster_options*]
 #   to add wsrep options to gcomm string
 #
+#[*automatic_bootstrap*]
+#   to bootstrap a galera cluster automagically
+#
+#[*bootstrapnode*]
+#   are we the node that should be started with bootstrap-pxc
+#
 # === Examples
 #
 #  ## For Percona XtraDB Cluster with exported resource support
@@ -133,6 +139,9 @@ class percona (
   $mysql_monitor_password = $percona::params::mysql_monitor_password,
 
   $wsrep_cluster_options  = $percona::params::wsrep_cluster_options,
+
+  $automatic_bootstrap    = false,
+  $bootstrapnode          = false,
 
 ) inherits percona::params {
 

--- a/manifests/stubs/bootstrapnode.pp
+++ b/manifests/stubs/bootstrapnode.pp
@@ -1,0 +1,11 @@
+# == Define: percona::stubs::bootstrapnode
+#
+# Definition that gets exported while the percona db bootstrapnode is in bootstrap mode
+#
+define percona::stubs::bootstrapnode (
+  $ip
+) {
+
+  # This is a stub, that gets collected by dalen/puppetdbquery
+
+}

--- a/manifests/stubs/clusternode.pp
+++ b/manifests/stubs/clusternode.pp
@@ -1,0 +1,12 @@
+# == Define: percona::stubs::clusternode
+#
+# Definition that gets exported when the percona node has successfully been started once
+#
+define percona::stubs::clusternode (
+  $ip
+) {
+
+  # This is a stub, that gets collected by dalen/puppetdbquery
+  # Ok folks, show's over, nothing to see here, ...
+
+}

--- a/manifests/virtual/service.pp
+++ b/manifests/virtual/service.pp
@@ -1,7 +1,0 @@
-# == Class percona::virtual:service
-#
-class percona::virtual::service {
-
-  @service { $percona::mysql_service_name: }
-
-}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "filiadata-percona",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "author": "filiadata",
   "summary": "Installs, configures, and manages percona xtradb cluster.",
   "license": "Apache-2.0",
@@ -46,6 +46,7 @@
   "description": "Module for Percona XtraDB Cluster",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.2"},
-    {"name":"richardc/datacat","version_requirement":">= 0.6.1"}
+    {"name":"richardc/datacat","version_requirement":">= 0.6.1"},
+    {"name":"dalen/puppetdbquery","version_requirement":">= 1.5.3"}
   ]
 }

--- a/spec/classes/percona_spec.rb
+++ b/spec/classes/percona_spec.rb
@@ -55,7 +55,8 @@ describe 'percona', :type => :class do
   end
   context 'with unsupported osfamily' do
     let :facts do
-      { :osfamily        => 'Darwin',
+      { :osfamily               => 'Darwin',
+        :operatingsystem        => 'Darwin',
         :operatingsystemrelease => '13.1.0',
         :concat_basedir         => '/dne',
         :is_pe                  => false,
@@ -65,7 +66,7 @@ describe 'percona', :type => :class do
     it do
       expect {
         catalogue
-      }.to raise_error(Puppet::Error, /Unsupported osfamily Darwin/)
+      }.to raise_error(Puppet::Error, /Unsupported platform: percona currently doesn't support Darwin or Darwin/)
     end
   end
 end


### PR DESCRIPTION
This PR adds functionality to autobootstrap a percona cluster. It heavily relies on facts and puppetdb to save state information. It starts the service on on all cluster nodes to create users, databases, ...

- The first node on the cluster has to be defined as the "bootstrap node".
- The bootstrap node asks puppetdb to check whether the cluster has already been started once.
- If it has not already been started, it starts the service in bootstrap mode and exports it's identity to the other cluster members via puppetdb.
- The other cluster members collect that information and start their services if connectivity to the bootstrap node succeeds. They set a local facts to prevent further automatic starts. In addition they export themselves to puppetdb to lock the bootstrap node from bootstrapping again.
- If the wsrep_cluster_size on the master is >= 3, the node restarts it's mysql service to exit bootstrap mode. It sets a fact to prevent further starts.
- Cluster setup is now complete.

@sasg, @martinpfeifer : What do you think?